### PR TITLE
Use oDate for date formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
     "jest": "^23.1.0",
-    "moment": "^2.22.1",
     "save-dev": "^2.0.0"
   }
 }

--- a/src/lib/mapEventData.js
+++ b/src/lib/mapEventData.js
@@ -1,11 +1,11 @@
-const moment = require('moment');
+const oDate = require('o-date');
 
 module.exports = (theEvent) => {
 	return {
 		id: theEvent.id,
 		eventTitle: theEvent.prefLabel,
 		mainImage: encodeURI(theEvent._imageUrl),
-		eventStart: moment(theEvent.scheduledStartTime).format('D MMMM YYYY'),
+		eventStart: oDate.format(theEvent.scheduledStartTime, 'dd MMMM yyyy'),
 		eventUrl: theEvent.eventURL,
 		eventLocation: 'London' //TODO get this from the tags
 	};


### PR DESCRIPTION
 🐿 v2.9.0

Moment.js was adding 200ish kb to our article `main.js`. o-date comes with a format function that can be used instead