### PR TITLE
removed template variant, animated is now default

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,9 @@
+const staticAssetsBasePath = 'https://www.ft.com/__assets/creatives/better-promo';
+
 module.exports = {
-	'apiPath': '/eventpromo/api/get-one/'
+	'apiPath': '/eventpromo/api/get-one/',
+	'animationStaticImages': [
+		`${staticAssetsBasePath}/break_out.jpg`,
+		`${staticAssetsBasePath}/audiance_clapping.jpg`
+	]
 };

--- a/src/lib/mapEventData.js
+++ b/src/lib/mapEventData.js
@@ -1,22 +1,13 @@
-const staticAssets = 'https://www.ft.com/__assets/creatives/better-promo/';
+const config = require('../config');
 const setDate = require('./event-date');
+
 module.exports = (theEvent, variant) => {
 	const eventUrl = new URL(theEvent.eventUrl);
-
-	//AB test logic remove/refactor on test conclusion
-	let images = [];
-	let showVariant = false;
-
-	if(variant === 'variant') {
-		showVariant = true;
-		images.push(
-			`${staticAssets}break_out.jpg`,
-			`${staticAssets}audiance_clapping.jpg`,
-			theEvent.imageUrl);
-	}
+	const images = [...config.animationStaticImages, theEvent.imageUrl];
+	const showVariant = (variant === 'variant');
 
 	eventUrl.searchParams.set('segmentId', theEvent.segmentId);
-	eventUrl.searchParams.set('variant', showVariant);
+	eventUrl.searchParams.set('variant', showVariant.toString());
 
 	return {
 		id: theEvent.id,

--- a/src/main.js
+++ b/src/main.js
@@ -36,9 +36,7 @@ async function eventPromoInit (rootEl) {
 	const mappedEvent = mapEventData(eventpromoClientResponse.eventpromo, showVariant);
 	promoSlotSelector.innerHTML = template(mappedEvent);
 
-	if(showVariant) {
-		animationToggle();
-	}
+	animationToggle();
 
 	return true;
 }

--- a/styles/_animation.scss
+++ b/styles/_animation.scss
@@ -1,4 +1,4 @@
-.event-promo--variant {
+.event-promo-animation {
 
 	.fade-0 {
 		opacity: 0;

--- a/styles/_inarticle-dark.scss
+++ b/styles/_inarticle-dark.scss
@@ -187,8 +187,7 @@
 	}
 }
 
-//variant specific styles
-.event-promo--variant {
+.event-promo-animation {
 
 	.event-promo__control {
 		cursor: pointer;

--- a/templates/inarticle_dark.html
+++ b/templates/inarticle_dark.html
@@ -1,4 +1,4 @@
-<div class="event-promo-inarticle {{#if showVariant}}event-promo--variant{{/if}}" data-event-focus="{{eventFocus}}"
+<div class="event-promo-inarticle event-promo-animation {{#if showVariant}}event-promo--variant{{/if}}" data-event-focus="{{eventFocus}}"
 data-focus-concept="{{id}}">
 	<div class="event-promo-inarticle__blocks">
 		<div class="event-promo__details">


### PR DESCRIPTION
- static image path moved to config
- variant flag now has no effect
- animated dark template is now default
- introduced  .event-promo-animation to replace .event-promo--variant specific styles
- left the flag logic in so that we can easily re-use it in future tests