### PR TITLE
return eventpromo data on eventPromoInit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ async function eventPromoInit (rootEl) {
 	const promoElement = <Eventpromo isPaused={false} {...mappedEvent} />;
     xEngine.render(promoElement, promoSlotSelector);
 
-	return true;
+	return mappedEvent;
 }
 
 export {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -138,7 +138,9 @@ describe('Unit tests: main', () => {
 				fetchMock.post(config.apiPath, liveEvent);
 				eventContainer.innerHTML = eventPromoDataEl;
 
-				expect(await eventPromoInit(document)).toEqual(true);
+                const eventData = await eventPromoInit(document);
+				expect(eventData.id).toEqual(liveEvent.eventpromo.id);
+				expect(eventData.segmentId).toEqual(liveEvent.eventpromo.segmentId);
 			});
 		});
 	});


### PR DESCRIPTION
We no longer attach the eventpromoId when we fire the o-tracking events with `n-eventpromo:shown``.
This is because next-article used to extract the eventpromoId from the injected DOM but this is no longer feasible using our new x-dash version.

More details: https://trello.com/c/VfO81tEZ/132-o-tracking-event-no-longer-includes-eventpromoid

Simple solution is to return the event data to the caller (next-article client in this case) so that it can do something with it without relying on the DOM structure.

 🐿 v2.10.3