### PR TITLE
Add role to button

### DIFF
--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -6,7 +6,7 @@ const Footer = ({ url }) => {
 	return (
 		<div className={styles['cta-container']}>
 			<div className={styles['btn-block']}>
-				<a href={url} className={styles['btn']} data-trackable="event-promo">
+				<a href={url} className={styles['btn']} data-trackable="event-promo" role="button">
 					Register now
 				</a>
 			</div>


### PR DESCRIPTION
Currently assistive tech considers this to be a link, but it is clearly styled as a button.

This is a problem for voice command users who might say eg "Click Button Register Now". Assistive tech doesn't know of any button with the title "Register Now" because this element is a _link_. 

Minimal effort fix for this is to give this element a "role=button"