### PR TITLE
Upgrade Origami modules to latest versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "o-buttons": "^6.0.2",
     "o-colors": "^5.0.2",
-    "o-grid": "^4.4.3",
+    "o-grid": "^5.0.0",
     "o-typography": "^6.0.1"
   },
   "homepage": "https://github.com/Financial-Times/n-eventpromo",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "private": true,
   "main": "dist/Eventpromo.es5.js",
   "dependencies": {
-    "o-buttons": "^5.14.0",
+    "o-buttons": "^6.0.2",
     "o-colors": "^4.7.2",
     "o-grid": "^4.4.3",
     "o-typography": "^5.7.5"

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "o-buttons": "^6.0.2",
     "o-colors": "^5.0.2",
     "o-grid": "^4.4.3",
-    "o-typography": "^5.7.5"
+    "o-typography": "^6.0.1"
   },
   "homepage": "https://github.com/Financial-Times/n-eventpromo",
   "description": "",

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "main": "dist/Eventpromo.es5.js",
   "dependencies": {
     "o-buttons": "^6.0.2",
-    "o-colors": "^4.7.2",
+    "o-colors": "^5.0.2",
     "o-grid": "^4.4.3",
     "o-typography": "^5.7.5"
   },

--- a/src/Details.scss
+++ b/src/Details.scss
@@ -9,7 +9,7 @@
 
 .details {
 	background-color: rgba(38, 42, 51, 0.9);
-	color: oColorsGetPaletteColor('white');
+	color: oColorsByName('white');
 	z-index: 5;
 	padding: $ep-standard-space;
 	display: flex;

--- a/src/Details.scss
+++ b/src/Details.scss
@@ -64,10 +64,10 @@
 	}
 
 	@include oGridRespondTo($from: M) {
-		@include oTypographyDisplay($scale: 6, $weight: 'bold');
+		@include oTypographyDisplay($scale: 6, $include-font-family: false);
 	}
 
 	@include oGridRespondTo(L, XL) {
-		@include oTypographyDisplay($scale: 5, $weight: 'bold');
+		@include oTypographyDisplay($scale: 5, $include-font-family: false);
 	}
 }

--- a/src/Details.scss
+++ b/src/Details.scss
@@ -53,7 +53,7 @@
 }
 .title {
 	display: inline-block;
-	@include oTypographyDisplayBold($scale: 5);
+	@include oTypographyDisplay($scale: 5, $weight: 'bold');
 	color: inherit;
 	text-decoration: none;
 	border: 0;
@@ -64,10 +64,10 @@
 	}
 
 	@include oGridRespondTo($from: M) {
-		@include oTypographyDisplayBold($scale: 6);
+		@include oTypographyDisplay($scale: 6, $weight: 'bold');
 	}
 
 	@include oGridRespondTo(L, XL) {
-		@include oTypographyDisplayBold($scale: 5);
+		@include oTypographyDisplay($scale: 5, $weight: 'bold');
 	}
 }

--- a/src/Footer.scss
+++ b/src/Footer.scss
@@ -32,9 +32,11 @@
 }
 
 .btn {
-	@include oButtons();
-	@include oButtonsTheme(inverse);
-	@include oButtonsSize(big); //event btn style overrides
+	@include oButtonsContent($opts: (
+		'size': 'big',
+		'theme': 'inverse',
+		'type': 'secondary',
+	));
 	background-color: rgb(60, 63, 69); // rgb(82,82,87);
 
 	@include oGridRespondTo($until: S) {

--- a/src/ImagesContainer.scss
+++ b/src/ImagesContainer.scss
@@ -43,7 +43,7 @@
 	vertical-align: baseline;
 	background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:pause?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=svg');
 	position: absolute;
-	color: oColorsGetPaletteColor('white');
+	color: oColorsByName('white');
 	background-color: rgba(38, 42, 51, 0.4);
 	border: 0 solid;
 }


### PR DESCRIPTION
Bumps the following to their latest version:
- `o-buttons`
- `o-colors`
- `o-typography`
- `o-grid`

When upgrading `o-buttons`, I chose to use the `oButtonsContent` mixin (instead of `oButtons`) because CSS Modules are being used in the templates, and I didn't want to make too many changes to the existing code.