### PR TITLE
Update FT live logo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "o-buttons": "^6.0.2",
     "o-colors": "^5.0.2",
     "o-grid": "^5.0.0",
+    "o-spacing": "^2.0.6",
     "o-typography": "^6.0.1"
   },
   "homepage": "https://github.com/Financial-Times/n-eventpromo",

--- a/src/Footer.scss
+++ b/src/Footer.scss
@@ -68,7 +68,8 @@
 		content: ' ';
 		width: 70px;
 		height: 60px;
-		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/specialisttitle-v1:brand-live-ft-logo?source=n-eventpromo');
+		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/specialisttitle-v1:brand-live-ft-logo-inverse?source=n-eventpromo');
+		margin-left: oSpacingByName('s2');
 	}
 	@include oGridRespondTo($until: S) {
 		align-self: flex-end;

--- a/src/styles/bootstrap.scss
+++ b/src/styles/bootstrap.scss
@@ -2,6 +2,7 @@
 @import 'o-colors/main';
 @import 'o-grid/main';
 @import 'o-typography/main';
+@import 'o-spacing/main';
 
 $ep-standard-space: 20px;
 $ep-half-space: $ep-standard-space/2;


### PR DESCRIPTION
Requested by the Commercial Design team. The new logo is shown in the screenshots below.
It is the same size as before but being square instead of circular I've added a little margin to the left.

![Screenshot 2020-09-16 at 16 51 43](https://user-images.githubusercontent.com/10405691/93361830-3428bd00-f83d-11ea-9ce4-6cafd0e1c626.png)
![Screenshot 2020-09-16 at 16 51 55](https://user-images.githubusercontent.com/10405691/93361837-3559ea00-f83d-11ea-836d-3714d0d910ea.png)
