### PR TITLE
CI-475: Rename master branch to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
-  filters_ignore_master: &filters_ignore_master
+  filters_ignore_main: &filters_ignore_main
     branches:
-      ignore: master
+      ignore: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -154,7 +154,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ npm install --save @financial-times/n-eventpromo @financial-times/x-engine
 
 This module also requires [`x-engine`][engine] as a peer dependency. The Engine module is used to inject your chosen runtime into the component. Please read the `x-engine` documentation first if you are consuming `x-` components for the first time in your application.
 
-[engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[engine]: https://github.com/Financial-Times/x-dash/tree/main/packages/x-engine
 
 ## Usage
 


### PR DESCRIPTION
In response to the endorsed proposal: [TGG: Address offensive and objectionable technology terms](https://docs.google.com/document/d/1v6z7_NkLFeYAFotTYB8C1OguO5iMHHLpAOv_yG5EKHI
).

Once this is merged I'll do the rest of the steps documented here:
https://github.com/Financial-Times/next/wiki/Migrating-apps-to-use-main-branch-(instead-of-master) 🐿 v2.13.0