### PR TITLE
fix: remove erroneous full-stop from ForumDetails modifier class use

### DIFF
--- a/src/Details.jsx
+++ b/src/Details.jsx
@@ -31,7 +31,7 @@ const ForumDetails = (props) => {
 			<h2 className={commonStyles['visually-hidden']}>
 				Forum details and information
 			</h2>
-			<div className={`${styles.details} ${styles['.details--ft-forums']}`}>
+			<div className={`${styles.details} ${styles['details--ft-forums']}`}>
 				<a href={props.link} className={styles.title} data-trackable="event-promo">
 					{props.title}
 				</a>


### PR DESCRIPTION
Because the class is brought in through js, its reference should not be prefixed with a `.`

This bug would have caused ForumPromos to be the wrong colour, had they been present in production. Fortunately, they were not yet implemented.