### PR TITLE
feat(HIVE-110): add support for Online Courses from the FT Board Director Programme

### DIFF
--- a/src/BrandLogo.jsx
+++ b/src/BrandLogo.jsx
@@ -1,21 +1,27 @@
 import xEngine from '@financial-times/x-engine';
-
 import styles from './BrandLogos.scss';
-import commonStyles from './styles/common.scss'
+import commonStyles from './styles/common.scss';
 
 export const FTLiveLogo = () => (
     <div className={`${styles['brand']} ${styles['brand--ft-live']}`}>
         Presented by
-        <span className={`${styles['brand__logo-alt-text']} ${commonStyles['visually-hidden']}`} >FT Live</span>
+        <span className={`${styles['brand__logo-alt-text']} ${commonStyles['visually-hidden']}`}>FT Live</span>
     </div>
-)
+);
 
 export const BDPLogo = () => (
     <div className={`${styles['brand']} ${styles['brand--ft-board-director-programme']}`}>
         Presented by
         <span className={`${styles['brand__logo-alt-text']} ${commonStyles['visually-hidden']}`}>FT Board Director Programme</span>
     </div>
-)
+);
+
+export const BDPLogoDark = () => (
+    <div className={`${styles['brand']} ${styles['brand--ft-board-director-programme-dark']}`}>
+        Presented by
+        <span className={`${styles['brand__logo-alt-text']} ${commonStyles['visually-hidden']}`}>FT Board Director Programme</span>
+    </div>
+);
 
 export const ForumsLogo = () => (
     <div className={`${styles['brand']} ${styles['brand--ft-forums']}`}>

--- a/src/BrandLogos.scss
+++ b/src/BrandLogos.scss
@@ -46,6 +46,12 @@
 	}
 }
 
+.brand--ft-board-director-programme-dark {
+	&:after {
+		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/specialisttitle-v1:board-director-programme?source=n-eventpromo');
+		width: 100px;
+	}
+}
 
 .visually-hidden {
 	@include oNormaliseVisuallyHidden();

--- a/src/Details.scss
+++ b/src/Details.scss
@@ -11,6 +11,7 @@
 	background-color: rgba(38, 42, 51, 0.9);
 	color: oColorsByName('white');
 	z-index: 5;
+	min-height: 250px;
 	padding: $ep-standard-space;
 	display: flex;
 	flex-flow: column;
@@ -53,6 +54,11 @@
 	background-color: rgba(108, 89, 153, 0.9);
 }
 
+.details--ft-board-director-programme-online-course {
+	color: oColorsByName('slate');
+	background-color: rgba(168, 207, 253, 0.9);
+}
+
 .strapline {
 	@include oTypographySans($scale: 2);
 	font-weight: 300;
@@ -84,10 +90,10 @@
 	}
 
 	@include oGridRespondTo($from: M) {
-	@include oTypographyDisplay($scale: 6, $include-font-family: false);
+		@include oTypographyDisplay($scale: 6, $include-font-family: false);
 	}
 
 	@include oGridRespondTo(L, XL) {
-	@include oTypographyDisplay($scale: 5, $include-font-family: false);
+		@include oTypographyDisplay($scale: 5, $include-font-family: false);
 	}
 }

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -1,12 +1,12 @@
 import xEngine from '@financial-times/x-engine';
-
 import styles from './Footer.scss';
 
-const Footer = ({link, ctaText, BrandLogo, defaultCtaText}) => {
+const Footer = ({link, ctaText, BrandLogo, defaultCtaText, darkButton}) => {
 	return (
 		<div className={styles['cta-container']}>
 			<div className={styles['btn-block']}>
-				<a href={link} className={styles['btn']} data-trackable="event-promo">
+				<a href={link} className={`${styles['btn']} ${darkButton ? styles['btn--dark'] : ''}`.trim()}
+				   data-trackable="event-promo">
 					{ctaText || defaultCtaText}
 				</a>
 			</div>

--- a/src/Footer.scss
+++ b/src/Footer.scss
@@ -45,7 +45,12 @@
 	@include oGridRespondTo($from: S) {
 		@include oTypographySans($scale: 2);
 	}
+}
 
+.btn--dark,
+.btn--dark:not([disabled]):hover {
+	border-color: oColorsByName('slate');
+	color: oColorsByName('slate');
 }
 
 .btn:not([disabled]):hover {

--- a/src/Meta.jsx
+++ b/src/Meta.jsx
@@ -4,8 +4,8 @@ import styles from './Meta.scss';
 const Meta = ({ location, dates }) => {
 	return (
 		<div className={styles.meta}>
-			<p>{location}</p>
-			<p>{dates}</p>
+			{!!location && <p>{location}</p>}
+			{!!dates && <p>{dates}</p>}
 		</div>
 	);
 };

--- a/src/utils/brands.js
+++ b/src/utils/brands.js
@@ -1,8 +1,9 @@
-import {BDPLogo, ForumsLogo, FTLiveLogo} from '../BrandLogo';
+import {BDPLogo, BDPLogoDark, ForumsLogo, FTLiveLogo} from '../BrandLogo';
 import detailStyles from '../Details.scss';
 
 const audienceClapping = 'https://www.ft.com/__assets/creatives/better-promo/audiance_clapping.jpg';
 const handShake = 'https://www.ft.com/__assets/creatives/better-promo/hand_shake.jpg';
+const calculator = 'https://www.ft.com/__assets/creatives/better-promo/calculator.jpg';
 
 const BRANDS = {
 	'ft-live': {
@@ -27,6 +28,13 @@ const BRANDS = {
 		defaultCtaText: 'Apply now',
 		defaultImageUrl: audienceClapping,
 		detailsModifierClassname: detailStyles['details--ft-board-director-programme-diploma']
+	},
+	'ft-bdp:online-course': {
+		BrandLogo: BDPLogoDark,
+		defaultCtaText: 'Book now',
+		defaultImageUrl: calculator,
+		detailsModifierClassname: detailStyles['details--ft-board-director-programme-online-course'],
+		darkButton: true
 	},
 	'ft-forums': {
 		BrandLogo: ForumsLogo,


### PR DESCRIPTION
# feat(HIVE-110): add support for Online Courses from the FT Board Director Programme

## What
- add support for events with no dates or location field
- add support for online courses brand

## Screenshot
![localhost_5005_eventpromo-demo_ft-bdp_online-course (2)](https://user-images.githubusercontent.com/11778762/119002305-ab8e8d80-b984-11eb-84ff-77065de34604.png)


