### PR TITLE
Increase the contrast when heading link in focus - CI-743

### DIFF
--- a/src/Details.scss
+++ b/src/Details.scss
@@ -81,7 +81,8 @@
 	border: 0;
 	padding-bottom: 8px;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		color: #c5cbd4;
 	}
 


### PR DESCRIPTION
### Problem
Currently the heading link for the event promo is using the default anchor focus color.

This color doesn't have enough contrast to the background.

### Fix
We are now reusing the hover color which does have adequate contrast.

**Contrast before fix**
<img width="734" alt="Screenshot of event promo without the fix applied" src="https://user-images.githubusercontent.com/524573/132123820-7440cfad-caa5-44f4-9012-fc5b01265fb2.png">

**Contrast after fix**
<img width="730" alt="Screenshot of event promo with the fix applied" src="https://user-images.githubusercontent.com/524573/132123818-f3272af3-28bb-4528-93f2-cf179fbe4df8.png">