### PR TITLE
CI-1022 Upgrade to npm7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,6 @@ jobs:
           name: Install project dependencies
           command: make install
       - run:
-          name: shared-helper / npm-install-peer-deps
-          command: .circleci/shared-helpers/helper-npm-install-peer-deps
-      - run:
           name: shared-helper / npm-update
           command: .circleci/shared-helpers/helper-npm-update
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,10 @@ references:
     branches:
       ignore: /.*/
 
-version: 2
+version: 2.1
+
+orbs:
+  node: circleci/node@4.9.0
 
 jobs:
 
@@ -67,6 +70,8 @@ jobs:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1 git@github.com:Financial-Times/next-ci-shared-helpers.git .circleci/shared-helpers
       - *restore_npm_cache
+      - node/install-npm:
+          version: "7"
       - run:
           name: Install project dependencies
           command: make install

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-postcss": "^2.0.0",
     "rollup-plugin-replace": "^2.1.0",
-    "snyk": "^1.167.2"
+    "snyk": "^1.167.2",
+    "stylelint": "^13.7.0",
+    "stylelint-order": "^4.0.0",
+    "stylelint-scss": "^3.17.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   },
   "homepage": "https://github.com/Financial-Times/n-eventpromo",
   "engines": {
-    "node": "12.x"
+    "node": "12.x",
+    "npm": "7.x || 8.x"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
[Ticket.](https://financialtimes.atlassian.net/browse/CI-1022)

This PR:
- Updates CircleCI config to use npm 7.
- Removes old helper for installing peer dependencies.
- Specifies npm 7 or 8 in package.json.
- Adds stylelint packages with specific versions to fix linter error.

Tested on:
http://localhost:5005/eventpromo-demo/ft-live
http://localhost:5005/eventpromo-demo/ft-forums
http://localhost:5005/eventpromo-demo/ft-bdp:workshop
http://localhost:5005/eventpromo-demo/ft-bdp:diploma
http://localhost:5005/eventpromo-demo/ft-bdp:masterclass
http://localhost:5005/eventpromo-demo/ft-bdp:online-course