### PR TITLE
[CI-669] Configure CI to wait for approval for renovate PRs on our repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ references:
     tags:
       ignore: /.*/
     branches:
-      ignore: /(^renovate-.*|^nori/.*|^main)/
+      ignore: /(^renovate-.*|^nori/.*)/
 
 version: 2.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,6 @@ references:
     branches:
       only: main
 
-  filters_ignore_main: &filters_ignore_main
-    branches:
-      ignore: main
-
   filters_ignore_tags: &filters_ignore_tags
     tags:
       ignore: /.*/
@@ -54,6 +50,16 @@ references:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
     branches:
       ignore: /.*/
+
+  filters_only_renovate_nori: &filters_only_renovate_nori
+    branches:
+      only: /(^renovate-.*|^nori/.*)/
+
+  filters_ignore_tags_renovate_nori: &filters_ignore_tags_renovate_nori
+    tags:
+      ignore: /.*/
+    branches:
+      ignore: /(^renovate-.*|^nori/.*|^main)/
 
 version: 2.1
 
@@ -133,7 +139,7 @@ workflows:
     jobs:
       - build:
           filters:
-            <<: *filters_ignore_tags
+            <<: *filters_ignore_tags_renovate_nori
       - test:
           requires:
             - build
@@ -154,6 +160,19 @@ workflows:
             <<: *filters_version_tag
           requires:
             - test
+
+  renovate-nori-build-test:
+    jobs:
+      - waiting-for-approval:
+          type: approval
+          filters:
+              <<: *filters_only_renovate_nori
+      - build:
+          requires:
+              - waiting-for-approval
+      - test:
+          requires:
+              - build
 
   nightly:
     triggers:


### PR DESCRIPTION
Configure CI to wait for approval for renovate PRs on our repos
[https://financialtimes.atlassian.net/browse/CI-669](https://financialtimes.atlassian.net/browse/CI-669)