### PR TITLE
changed margin-bottom of the btn container

### DIFF
--- a/src/Eventpromo.scss
+++ b/src/Eventpromo.scss
@@ -21,7 +21,7 @@
 .eventpromo__btn__container {
 	max-width: 700px;
 	text-align: center;
-	margin-bottom: 48px;
+	margin-bottom: 24px;
 }
 
 .explore__btn {


### PR DESCRIPTION
### What
Changed the margin-bottom of the button container as the whole better promo exists in an article container that also has margin bottom with 24px which combined together creates a big gap.

Before:
![image](https://github.com/Financial-Times/n-eventpromo/assets/105658311/10b4f080-932e-4a7b-b02b-b1a018f135df)
After:
![image](https://github.com/Financial-Times/n-eventpromo/assets/105658311/353af951-ea09-426d-a123-671880ebc0aa)
