### PR TITLE
Remove snyk [automated]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
-patch: {}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"test": "dotcom-tool-kit test:local",
 		"precommit": "secret-squirrel && npm run format && npm run fix",
 		"prepush": "npm run test",
-		"prepare": "npx snyk protect || npx snyk protect -d || true && husky install",
+		"prepare": "husky install",
 		"build": "dotcom-tool-kit build:local",
 		"start": "dotcom-tool-kit run:local",
 		"fix:js": "eslint --fix '**/*.{js,json,yml}'",
@@ -69,7 +69,6 @@
 		"rollup-plugin-postcss": "^2.9.0",
 		"rollup-plugin-replace": "^2.1.0",
 		"sass": "^1.50.1",
-		"snyk": "^1.167.2",
 		"stylelint": "^13.7.0",
 		"stylelint-order": "^4.0.0",
 		"stylelint-scss": "^3.17.1"


### PR DESCRIPTION
In mid-December 2024 we will be letting our Snyk contract expire. We'll
be moving to GitHub Advanced Security as an alternative.

This PR is an attempt to get ahead of the deadline. Considering how out
of date some of our Snyk implementations are, and that we rarely take
the time to merge the PRs, we think it's fine to remove it way ahead of
time.

If you want an interrim solution, enable Dependabot Security updates for
this repository by visiting the following page and clicking 'Enable' next
to 'Dependabot security updates':
https://github.com/Financial-Times/n-eventpromo/settings/security_analysis

You're also free to ignore this PR and do the work yourself closer to
the deadline. Cyber will be doing some broader comms later in the year.

This PR was automated, please take a little extra care when reviewing. I
won't be attempting to fix build failures or small repo-specific quirks
but feel free to build on top of this PR.